### PR TITLE
Include index in for to be used as key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ The \<If\> body must return a single JSX root element. You can even nest!
 
 ```
 <For each="fruit" of={this.props.fruits}>
-  <li key={fruit}>{fruit}</li>
+  <li key={i}>{fruit}</li>
 </For>
 ```
 
 this becomes
 
 ```
-this.props.fruits.map(function(fruit) { return (
-  <li key={fruit}>{fruit}</li>
+this.props.fruits.map(function(fruit, i) { return (
+  <li key={i}>{fruit}</li>
 )}, this)
 ```
 

--- a/for.js
+++ b/for.js
@@ -41,7 +41,7 @@ function visitJSXOpeningElement(traverse, object, path, state) {
   utils.append('.map(function(', state);
   utils.move(eachCondition.value.range[0] + 1, state);
   utils.catchup(eachCondition.value.range[1] - 1, state);
-  utils.append(') { return (', state);
+  utils.append(', i) { return (', state);
   utils.move(object.range[1], state);
 }
 visitJSXOpeningElement.test = function(object, path, state) {


### PR DESCRIPTION
Currently, the `For` component does not provide a key to be used in its children. This makes developers to rely in a key within the object. This is not a best practice according to the documentation. See the following links for further reasoning:

https://github.com/mikechau/react-primer-draft#key

Moreover, sometimes there may not be a unique property within the elements being listed.

This PR adds an index argument (as `i`) for the `map()` callback so children elements can use it:

```
<For each="item" of={this.props.data}>
  <li key={item._source.slug}><Link to={item._source.slug}>{item._source.title}</Link></li>
</For>
```

Currently, the above JSX will generate this JavaScript:
```javascript
React.createElement("ul", null, 
  this.props.data.map(function(item) { return (
    React.createElement("li", {key: item._source.slug}, React.createElement(Link, {to: item._source.slug}, item._source.title))
  );}, this)
)
```

While this pull request makes available the `i` index so we can use it:

```
<For each="item" of={this.props.data}>
  <li key={i}><Link to={item._source.slug}>{item._source.title}</Link></li>
</For>
```

Which then translates to the following:

```javascript
React.createElement("ul", null, 
  this.props.data.map(function(item, i) { return (
    React.createElement("li", {key: i}, React.createElement(Link, {to: item._source.slug}, item._source.title))
  );}, this)
)
```